### PR TITLE
adding the controlType to the API and always set the idIsLocal to false

### DIFF
--- a/src/changeUtils.js
+++ b/src/changeUtils.js
@@ -57,7 +57,6 @@ function getProjectId(manifest, reference) {
 }
 
 function createString(propertyBag) {
-
 	return JSON.stringify({
 		fileName: propertyBag.id || uid().replace(/-/g, "_") + "_" + propertyBag.type,
 		fileType: "change",
@@ -68,7 +67,8 @@ function createString(propertyBag) {
 		content: propertyBag.content || {},
 		selector: {
 			id: propertyBag.controlId,
-			idIsLocal: true
+			idIsLocal: false,
+			type: propertyBag.controlType
 		},
 		layer: propertyBag.isCustomer ? "CUSTOMER_BASE" : "VENDOR",
 		texts: {},
@@ -169,6 +169,7 @@ module.exports = {
 			projectId: change.projectId,
 			type: change.changeType,
 			controlId: change.selector.id,
+			controlType: change.selector.type,
 			isCustomer: change.layer === "CUSTOMER_BASE",
 			creatingTool: change.support.generator.replace(CHANGE_UTILS_PREFIX, ""),
 			content: change.content,

--- a/test/changeUtils.js
+++ b/test/changeUtils.js
@@ -38,6 +38,7 @@ const completeChange = {
 	creation: 1585730948833,
 	type: "propertyChange",
 	controlId: "myTable",
+	controlType: "sap.m.Table",
 	projectId: "",
 	isCustomer: true,
 	creatingTool: "ava test",
@@ -51,13 +52,14 @@ const completeChange = {
 const changeInCreation = clone(completeChange, ["id", "reference", "appVersion", "projectId"]);
 
 test("changeUtils parses", (t) => {
-	const change = changeUtils.parse("{\"fileName\":\"id_1585730948833_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":true},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"test.app\",\"creation\":1585730948833,\"originalLanguage\":\"\",\"support\":{\"sapui5Version\": \"1.77.0\",\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}");
+	const change = changeUtils.parse("{\"fileName\":\"id_1585730948833_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":false,\"type\":\"sap.m.Table\"},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"test.app\",\"creation\":1585730948833,\"originalLanguage\":\"\",\"support\":{\"sapui5Version\": \"1.77.0\",\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}");
 	t.deepEqual(change, {
 		id: "id_1585730948833_0_propertyChange",
 		type: "propertyChange",
 		reference: "test.app",
 		appVersion: "1.0.0",
 		controlId: "myTable",
+		controlType: "sap.m.Table",
 		isCustomer: true,
 		creatingTool: "ava test",
 		creation: 1585730948833,
@@ -106,7 +108,7 @@ test("changeUtils createChangeString create a change (manifest is provided)", (t
 		"\"fileName\":\"id_123_0_propertyChange\""
 	);
 	stringifiedChange = stringifiedChange.replace(/"creation":[0-9]*/, "\"creation\":0");
-	t.deepEqual(stringifiedChange, "{\"fileName\":\"id_123_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":true},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"\",\"creation\":0,\"originalLanguage\":\"\",\"support\":{\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}", "then the change string is generated correct");
+	t.deepEqual(stringifiedChange, "{\"fileName\":\"id_123_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":false,\"type\":\"sap.m.Table\"},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"\",\"creation\":0,\"originalLanguage\":\"\",\"support\":{\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}", "then the change string is generated correct");
 });
 
 test("changeUtils createChangeString create a change (manifest is provided based on fiori elements)", (t) => {
@@ -118,10 +120,10 @@ test("changeUtils createChangeString create a change (manifest is provided based
 		"\"fileName\":\"id_123_0_propertyChange\""
 	);
 	stringifiedChange = stringifiedChange.replace(/"creation":[0-9]*/, "\"creation\":0");
-	t.deepEqual(stringifiedChange, "{\"fileName\":\"id_123_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":true},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"test.app\",\"creation\":0,\"originalLanguage\":\"\",\"support\":{\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}", "then the change string is generated correct");
+	t.deepEqual(stringifiedChange, "{\"fileName\":\"id_123_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":false,\"type\":\"sap.m.Table\"},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"test.app\",\"creation\":0,\"originalLanguage\":\"\",\"support\":{\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}", "then the change string is generated correct");
 });
 
 test("changeUtils toString strigifies a change again (id, reference, appVersion provided; manifest not provided)", (t) => {
 	const stringifiedChange = changeUtils.toString(completeChange);
-	t.deepEqual(stringifiedChange, "{\"fileName\":\"id_123_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":true},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"\",\"creation\":1585730948833,\"originalLanguage\":\"\",\"support\":{\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}", "then the change string is generated correct");
+	t.deepEqual(stringifiedChange, "{\"fileName\":\"id_123_0_propertyChange\",\"fileType\":\"change\",\"changeType\":\"propertyChange\",\"moduleName\":\"\",\"reference\":\"test.app\",\"packageName\":\"\",\"content\":{\"property\":\"exportToExcel\",\"newValue\":true},\"selector\":{\"id\":\"myTable\",\"idIsLocal\":false,\"type\":\"sap.m.Table\"},\"layer\":\"CUSTOMER_BASE\",\"texts\":{},\"namespace\":\"apps/test.app/changes/\",\"projectId\":\"\",\"creation\":1585730948833,\"originalLanguage\":\"\",\"support\":{\"generator\":\"changeUtils: ava test\",\"service\":\"\",\"user\":\"\",\"sourceChangeFileName\":\"\",\"compositeCommand\":\"\"},\"oDataInformation\":{},\"dependentSelector\":{},\"validAppVersions\":{\"from\":\"1.0.0\",\"to\":\"1.0.0\",\"creation\":\"1.0.0\"},\"jsOnly\":false,\"variantReference\":\"\",\"appDescriptorChange\":false}", "then the change string is generated correct");
 });


### PR DESCRIPTION
* since there is no runtime there cannot be local IDs
* the control type must be known by the consumer -> it is now exposed